### PR TITLE
Fix: 공지사항 수정이 안되는 현상 수정

### DIFF
--- a/src/main/java/com/goodee/finals/notice/NoticeService.java
+++ b/src/main/java/com/goodee/finals/notice/NoticeService.java
@@ -101,6 +101,14 @@ public class NoticeService {
 
 	@Transactional
 	public NoticeDTO edit(NoticeDTO noticeDTO, MultipartFile[] files, List<Long> deleteFiles) {
+		String editTitle = noticeDTO.getNoticeTitle();
+		String editContent = noticeDTO.getNoticeContent();
+		boolean editPinned = noticeDTO.isNoticePinned();
+
+		noticeDTO = noticeRepository.findById(noticeDTO.getNoticeNum()).get();
+		noticeDTO.setNoticeTitle(editTitle);
+		noticeDTO.setNoticeContent(editContent);
+		noticeDTO.setNoticePinned(editPinned);
 		
 		if (deleteFiles != null && deleteFiles.size() > 0) {
 			for (Long attachNum : deleteFiles) {


### PR DESCRIPTION
* NoticeService에서 수정을 처리하는 메서드에서 매개변수로 받아온 NoticeDTO 엔티티를 JPA의 save메서드의 매개변수로 등록하려고 하니 에러가 발생했습니다. JPA를 사용할 때는 JPA가 관리하는 엔티티를 save의 매개변수로 등록해야하는 것 같습니다.